### PR TITLE
Add callback hooks to power iterations and provide examples

### DIFF
--- a/examples/batched_minres.py
+++ b/examples/batched_minres.py
@@ -1,0 +1,42 @@
+import logging
+import os
+import sys
+import numpy as np
+import scipy.sparse as sp
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from util import random_expander_like_matrix, power_solve_cb, make_minres_callback
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def make_spd_matrix(n: int, nnz_per_row: int, seed: int = 0):
+    A = random_expander_like_matrix(n, nnz_per_row, seed=seed, backend="numpy")
+    rng = np.random.default_rng(seed)
+    A.data = rng.uniform(-1.0, 1.0, size=A.nnz)
+    A = (A + A.T).tocsr() * 0.5
+    A = A + sp.eye(n, format="csr", dtype=A.dtype)
+    A = A.T @ A
+    return A
+
+def main():
+    n = 64
+    k = 4
+    A = make_spd_matrix(n, 4, seed=1)
+    V = np.linalg.qr(np.random.standard_normal((n, k)))[0]
+
+    def cb(V, w, relres):
+        thresh = 1e-6
+        converged = relres < thresh
+        num = int(np.count_nonzero(converged))
+        if num < len(relres):
+            next_rel = float(relres[~converged].min())
+            logger.info("%d eigenvalues converged, next relres %.3e", num, next_rel)
+        else:
+            logger.info("all %d eigenvalues converged", num)
+
+    inv_cb = make_minres_callback(rtol=1e-4, maxiter=50, backend="numpy")
+    power_solve_cb(A, V, inv_cb, outer_iter=5, backend="numpy", callback=cb)
+
+if __name__ == "__main__":
+    main()

--- a/examples/block_chebyshev.py
+++ b/examples/block_chebyshev.py
@@ -1,0 +1,44 @@
+import logging
+import os
+import sys
+import numpy as np
+import scipy.sparse as sp
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from util import random_expander_like_matrix, power_cheb
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def make_spd_matrix(n: int, nnz_per_row: int, seed: int = 0):
+    A = random_expander_like_matrix(n, nnz_per_row, seed=seed, backend="numpy")
+    rng = np.random.default_rng(seed)
+    A.data = rng.uniform(-1.0, 1.0, size=A.nnz)
+    A = (A + A.T).tocsr() * 0.5
+    A = A + sp.eye(n, format="csr", dtype=A.dtype)
+    A = A.T @ A
+    return A
+
+def main():
+    n = 64
+    k = 4
+    A = make_spd_matrix(n, 4, seed=0)
+    V = np.linalg.qr(np.random.standard_normal((n, k)))[0]
+
+    vals = np.linalg.eigvalsh(A.toarray())
+    eig_min, eig_max = float(vals.min()), float(vals.max())
+
+    def cb(V, w, relres):
+        thresh = 1e-6
+        converged = relres < thresh
+        num = int(np.count_nonzero(converged))
+        if num < len(relres):
+            next_rel = float(relres[~converged].min())
+            logger.info("%d eigenvalues converged, next relres %.3e", num, next_rel)
+        else:
+            logger.info("all %d eigenvalues converged", num)
+
+    power_cheb(A, V, eig_min, eig_max, outer_iter=5, inner_iter=5, backend="numpy", callback=cb)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add optional callbacks to `power_cheb` and `power_solve_cb`
- include logging-based examples for block Chebyshev and batched MINRES power iterations

## Testing
- `python -m py_compile util.py examples/block_chebyshev.py examples/batched_minres.py`
- `python examples/block_chebyshev.py`
- `python examples/batched_minres.py`


------
https://chatgpt.com/codex/tasks/task_e_68acf5b836188328af0dc58b729c5944