### PR TITLE
Remove built-in plotting hooks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,2 @@
-contourpy==1.3.2
-cycler==0.12.1
-fonttools==4.59.1
-kiwisolver==1.4.9
-matplotlib==3.10.5
 numpy==2.2.6
-packaging==25.0
-pillow==11.3.0
-pyparsing==3.2.3
-python-dateutil==2.9.0.post0
 scipy==1.15.3
-six==1.17.0


### PR DESCRIPTION
## Summary
- remove matplotlib imports and `plots` arguments
- rely on callbacks for residual handling
- trim requirements to just numpy and scipy

## Testing
- `python -m py_compile util.py`
- `python examples/block_chebyshev.py`
- `python examples/batched_minres.py`


------
https://chatgpt.com/codex/tasks/task_e_68acfc3f903c83288a8c269477c83818