### PR TITLE
Fix CuPy backend norm handling and optional SciPy

### DIFF
--- a/examples/nonsym_deflated_minres.py
+++ b/examples/nonsym_deflated_minres.py
@@ -61,7 +61,11 @@ def main():
     V0 = xp.asarray(rng.standard_normal((2 * n, args.k)))
     V0, _ = xp.linalg.qr(V0)
 
-    Anorm = float(xp.abs(Asym).sum(axis=1).max())
+    Asym_abs = Asym.copy()
+    Asym_abs.data = xp.abs(Asym_abs.data)
+    row_sums = Asym_abs.sum(axis=1)
+    row_sums = xp.asarray(row_sums).ravel()
+    Anorm = float(row_sums.max())
 
     def power_cb(V, w, _):
         AV = Asym @ V

--- a/util.py
+++ b/util.py
@@ -19,9 +19,22 @@ except Exception:
     _CUPY_AVAILABLE = False
 
 import numpy as _np
-import scipy.sparse as _sps
-from scipy.sparse.linalg import LinearOperator as _NpLinearOperator, minres as _np_minres
-from scipy.linalg import solve_triangular as _np_solve_tri
+
+# Optional SciPy import (only if available)
+try:
+    import scipy.sparse as _sps
+    from scipy.sparse.linalg import (
+        LinearOperator as _NpLinearOperator,
+        minres as _np_minres,
+    )
+    from scipy.linalg import solve_triangular as _np_solve_tri
+    _SCIPY_AVAILABLE = True
+except Exception:
+    _sps = None
+    _NpLinearOperator = None
+    _np_minres = None
+    _np_solve_tri = None
+    _SCIPY_AVAILABLE = False
 
 
 # ------------------------ Backend plumbing ------------------------
@@ -41,6 +54,10 @@ class _Backend:
             self.asfortranarray = _cp.asfortranarray
             self.copyto = _cp.copyto
         elif name == "numpy":
+            if not _SCIPY_AVAILABLE:
+                raise RuntimeError(
+                    "NumPy backend requested but SciPy is not available."
+                )
             self.name = "numpy"
             self.xp = _np
             self.sp = _sps


### PR DESCRIPTION
## Summary
- compute matrix infinity norm via sparse data to support CuPy backend
- guard NumPy backend behind optional SciPy import so CuPy-only setups work

## Testing
- `python -m py_compile util.py examples/nonsym_deflated_minres.py`
- `python examples/nonsym_deflated_minres.py --power-iters=1 --inner-rtol=1e-6 --inner-maxiter=5 --backend=numpy 20 4 3`
- `python examples/nonsym_deflated_minres.py --power-iters=1 --inner-rtol=1e-6 --inner-maxiter=5 --backend=cupy 20 4 3` *(fails: CuPy backend requested but CuPy is not available)*

------
https://chatgpt.com/codex/tasks/task_e_68bacaf7192883288083a3ed3b84c1f1